### PR TITLE
Updated reflect-metadata dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "playwright-bdd": "^7.4.0"
   },
   "dependencies": {
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "reflect-metadata": "^0.2.2"
   }
 }


### PR DESCRIPTION
From the npm install:
"npm warn deprecated reflect-metadata@0.2.1: This version has a critical bug in fallback handling. Please upgrade to reflect-metadata@0.2.2 or newer."